### PR TITLE
Update version number to v1.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = "GPL-3.0-or-later"
 keywords = ["awk", "debugger", "debugging", "tui"]
 categories = ["command-line-utilities", "development-tools", "development-tools::debugging"]
-version = "1.2.1"
+version = "1.2.2"
 authors = ["Petr Šťastný <petr.stastny01@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Desed has released v1.2.2 but the version variable has not been synced. Just a quick PR to fix this, let me know if anything else is needed.