### PR TITLE
refactor(tui): bump ratatui and simplify the usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,6 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "clap",
- "crossterm",
  "inotify",
  "kqueue",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ edition = "2018"
 # Parsing CLI arguments
 clap = { version = "4", features = ["cargo"] }
 # TUI
-crossterm = "0.28.0"
-tui = { package = "ratatui", version = "0.28.0", default-features = false, features = ["crossterm"] }
+ratatui = "0.28.1"
 # Flexible error handling
 anyhow = "1.0.65"
 # For easier handling of conditional compilation


### PR DESCRIPTION
`ratatui` now re-exports `crossterm` so we can simplify the code a bit :)
